### PR TITLE
Remove the error during configuration preparation.

### DIFF
--- a/filefs/usr/local/bin/_startup.sh
+++ b/filefs/usr/local/bin/_startup.sh
@@ -1,23 +1,23 @@
 #!/bin/sh
 echo "Preparing Config Folder"
 if [ -d "/config/guacamole/" ]; then
-  rm /config/guacamole/extensions/guacamole-auth-duo-*.jar
-  rm /config/guacamole/extensions/guacamole-auth-header-*.jar
-  rm /config/guacamole/extensions/guacamole-auth-jdbc-mysql-*.jar
-  rm /config/guacamole/extensions/guacamole-auth-jdbc-postgresql-*.jar
-  rm /config/guacamole/extensions/guacamole-auth-jdbc-sqlserver-*.jar
-  rm /config/guacamole/extensions/guacamole-auth-json-*.jar
-  rm /config/guacamole/extensions/guacamole-auth-ldap-*.jar
-  rm /config/guacamole/extensions/guacamole-auth-quickconnect-*.jar
-  rm /config/guacamole/extensions/guacamole-auth-sso-openid-*.jar
-  rm /config/guacamole/extensions/guacamole-auth-sso-saml-*.jar
-  rm /config/guacamole/extensions/guacamole-auth-sso-cas-*.jar
-  rm /config/guacamole/extensions/guacamole-auth-totp-*.jar
-  rm /config/guacamole/extensions/guacamole-vault-ksm-*.jar
-  rm /config/guacamole/extensions/guacamole-history-recording-storage-*.jar
-  rm -r /config/guacamole/extensions-available
-  rm -r /config/guacamole/lib
-  rm -r /config/guacamole/schema
+  rm -f /config/guacamole/extensions/guacamole-auth-duo-*.jar
+  rm -f /config/guacamole/extensions/guacamole-auth-header-*.jar
+  rm -f /config/guacamole/extensions/guacamole-auth-jdbc-mysql-*.jar
+  rm -f /config/guacamole/extensions/guacamole-auth-jdbc-postgresql-*.jar
+  rm -f /config/guacamole/extensions/guacamole-auth-jdbc-sqlserver-*.jar
+  rm -f /config/guacamole/extensions/guacamole-auth-json-*.jar
+  rm -f /config/guacamole/extensions/guacamole-auth-ldap-*.jar
+  rm -f /config/guacamole/extensions/guacamole-auth-quickconnect-*.jar
+  rm -f /config/guacamole/extensions/guacamole-auth-sso-openid-*.jar
+  rm -f /config/guacamole/extensions/guacamole-auth-sso-saml-*.jar
+  rm -f /config/guacamole/extensions/guacamole-auth-sso-cas-*.jar
+  rm -f /config/guacamole/extensions/guacamole-auth-totp-*.jar
+  rm -f /config/guacamole/extensions/guacamole-vault-ksm-*.jar
+  rm -f /config/guacamole/extensions/guacamole-history-recording-storage-*.jar
+  rm -rf /config/guacamole/extensions-available
+  rm -rf /config/guacamole/lib
+  rm -rf /config/guacamole/schema
   cp -r /app/guacamole/extensions/*.jar /config/guacamole/extensions
   cp -r /app/guacamole/extensions-available /config/guacamole
   cp -r /app/guacamole/lib /config/guacamole


### PR DESCRIPTION
Hello,

I have included -f argument on the rm commands in the startup script. This prevents errors at the start of the container when these addons are not used:

```
rm: can't remove '/config/guacamole/extensions/guacamole-auth-duo-*.jar': No such file or directory
rm: can't remove '/config/guacamole/extensions/guacamole-auth-header-*.jar': No such file or directory
rm: can't remove '/config/guacamole/extensions/guacamole-auth-jdbc-mysql-*.jar': No such file or directory
rm: can't remove '/config/guacamole/extensions/guacamole-auth-jdbc-sqlserver-*.jar': No such file or directory
rm: can't remove '/config/guacamole/extensions/guacamole-auth-json-*.jar': No such file or directory
rm: can't remove '/config/guacamole/extensions/guacamole-auth-ldap-*.jar': No such file or directory
rm: can't remove '/config/guacamole/extensions/guacamole-auth-quickconnect-*.jar': No such file or directory
rm: can't remove '/config/guacamole/extensions/guacamole-auth-sso-openid-*.jar': No such file or directory
rm: can't remove '/config/guacamole/extensions/guacamole-auth-sso-saml-*.jar': No such file or directory
rm: can't remove '/config/guacamole/extensions/guacamole-auth-sso-cas-*.jar': No such file or directory
rm: can't remove '/config/guacamole/extensions/guacamole-auth-totp-*.jar': No such file or directory
rm: can't remove '/config/guacamole/extensions/guacamole-vault-ksm-*.jar': No such file or directory
rm: can't remove '/config/guacamole/extensions/guacamole-history-recording-storage-*.jar': No such file or directory
```